### PR TITLE
DNSConfig propagation strategy

### DIFF
--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -334,7 +334,7 @@ func (r *registry) processStep(step *api.TestStep, seen sets.Set[string], stack 
 		ret.Dependencies = deps
 	}
 
-	if ret.DNSConfig != nil {
+	if ret.DNSConfig == nil {
 		ret.DNSConfig = stack.resolveDNS(ret.DNSConfig)
 	}
 	return ret, errs


### PR DESCRIPTION
I wasn't very convinced about the propagation strategy while reviewing https://github.com/openshift/ci-tools/pull/3687, so instead of keep commenting on that PR I thought it would have been more clear to just push some code and show my intentions.

The mechanism is quite simple: a `DNSConfig` gets overridden by the closest `DNSConfig` in the ancestors chain if it is `nil` otherwise it is left untouched.

I've also created a new unit test for you to play with, in which is straightforward to configure `workflows`, `chains`, `refs` and the `test` to resolve. 